### PR TITLE
Add level transition animation

### DIFF
--- a/src/components/games/BreakoutGame.jsx
+++ b/src/components/games/BreakoutGame.jsx
@@ -14,6 +14,7 @@ export const BreakoutGame = ({ settings, updateHighScore }) => {
   const [lives, setLives] = useState(3);
   const [gameOver, setGameOver] = useState(false);
   const [paused, setPaused] = useState(false);
+  const [transitioning, setTransitioning] = useState(false);
   const [level, setLevel] = useState(1);
   const [scoreFlash, setScoreFlash] = useState(false);
   const prevScore = useRef(0);
@@ -117,7 +118,7 @@ export const BreakoutGame = ({ settings, updateHighScore }) => {
     };
 
     const gameLoop = (timestamp) => {
-      if (!paused && !gameOver) {
+      if (!paused && !gameOver && !transitioning) {
         const game = gameRef.current;
         
         // Update ball
@@ -248,10 +249,16 @@ export const BreakoutGame = ({ settings, updateHighScore }) => {
         });
 
         // Check level complete
-        if (game.bricks.length === 0) {
-          setLevel(l => l + 1);
+        if (game.bricks.length === 0 && !transitioning) {
+          setTransitioning(true);
+          setPaused(true);
           soundManager.playPowerUp();
-          initBricks();
+          setTimeout(() => {
+            setLevel(l => l + 1);
+            initBricks();
+            setPaused(false);
+            setTransitioning(false);
+          }, 700);
         }
       }
 
@@ -333,6 +340,7 @@ export const BreakoutGame = ({ settings, updateHighScore }) => {
     setLives(3);
     setLevel(1);
     setGameOver(false);
+    setTransitioning(false);
     setPaused(false);
     initBricks();
   };
@@ -359,7 +367,7 @@ export const BreakoutGame = ({ settings, updateHighScore }) => {
         </div>
       </div>
       
-      <FadingCanvas active={!gameOver}>
+      <FadingCanvas active={!gameOver && !transitioning} slide={transitioning}>
         <canvas
           ref={canvasRef}
           className="border-2 border-red-500 rounded-lg shadow-lg shadow-red-500/50 cursor-none touch-none"

--- a/src/components/ui/FadingCanvas.jsx
+++ b/src/components/ui/FadingCanvas.jsx
@@ -1,13 +1,17 @@
 import React, { useEffect, useState } from 'react';
 
-export const FadingCanvas = ({ active, children }) => {
+export const FadingCanvas = ({ active, slide = false, children }) => {
   const [visible, setVisible] = useState(active);
 
   useEffect(() => {
     setVisible(active);
   }, [active]);
 
+  const classes = slide
+    ? `transition-all duration-700 transform ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`
+    : `transition-opacity duration-700 ${visible ? 'opacity-100' : 'opacity-0'}`;
+
   return (
-    <div className={`transition-opacity duration-700 ${visible ? 'opacity-100' : 'opacity-0'}`}>{children}</div>
+    <div className={classes}>{children}</div>
   );
 };


### PR DESCRIPTION
## Summary
- enable sliding fade effect in `FadingCanvas`
- trigger fade/slide when all bricks are cleared in Breakout
- hold game updates until the animation finishes

## Testing
- `npm run build`
