### PR TITLE
Fix Pac-Man high score key

### DIFF
--- a/src/components/games/PacManGame.tsx
+++ b/src/components/games/PacManGame.tsx
@@ -656,7 +656,7 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
             const newLives = prev - 1;
             if (newLives <= 0) {
               setGameOver(true);
-              updateHighScore('pac-man', score);
+              updateHighScore('pacman', score);
               if (settings.sound) {
                 soundManager.playGameOver();
               }


### PR DESCRIPTION
## Summary
- correct Pac-Man's high score key to match GameId union

## Testing
- `npm run build`
- `node test-pacman.js` *(fails: Playwright browsers missing)*