### PR TITLE
Fix particle manager usage

### DIFF
--- a/src/components/games/BreakoutGame.tsx
+++ b/src/components/games/BreakoutGame.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Heart, Play, Pause, RotateCcw } from 'lucide-react';
 import { soundManager } from '../../core/SoundManager';
-import { Particle, particleManager } from '../../core/ParticleSystem';
+import { particleManager } from '../../core/ParticleSystem';
 import { FadingCanvas } from "../ui/FadingCanvas";
 import { GameOverBanner } from "../ui/GameOverBanner";
 import { GameProps, Brick } from '../../core/GameTypes';
@@ -26,7 +26,6 @@ interface GameRef {
   ball: Ball;
   paddle: Paddle;
   bricks: Brick[];
-  particles: Particle[];
   powerUps: any[];
 }
 
@@ -54,7 +53,6 @@ export const BreakoutGame: React.FC<GameProps> = ({ settings, updateHighScore })
     ballVY: -4,
     ballSize: 8,
     bricks: [],
-    particles: [],
     powerUps: [],
     lastUpdate: 0
   });
@@ -188,7 +186,7 @@ export const BreakoutGame: React.FC<GameProps> = ({ settings, updateHighScore })
 
     const createParticles = (x, y, color) => {
       for (let i = 0; i < 15; i++) {
-        const particle = particleManager.addParticle({
+        particleManager.addParticle({
           x: x,
           y: y,
           vx: (Math.random() - 0.5) * 200,
@@ -197,9 +195,6 @@ export const BreakoutGame: React.FC<GameProps> = ({ settings, updateHighScore })
           life: 0.8,
           size: 2
         });
-        if (particle) {
-          gameRef.current.particles.push(particle);
-        }
       }
     };
 
@@ -383,10 +378,7 @@ export const BreakoutGame: React.FC<GameProps> = ({ settings, updateHighScore })
       }
 
       // Update particles
-      gameRef.current.particles = gameRef.current.particles.filter(p => {
-        p.update(0.016);
-        return p.life > 0;
-      });
+      particleManager.getParticleSystem().update(0.016);
 
       // Draw
       ctx.fillStyle = '#0f172a';
@@ -435,7 +427,7 @@ export const BreakoutGame: React.FC<GameProps> = ({ settings, updateHighScore })
       });
 
       // Draw particles
-      gameRef.current.particles.forEach(p => p.draw(ctx));
+      particleManager.getParticleSystem().draw(ctx);
 
       animationId = requestAnimationFrame(gameLoop);
     };

--- a/src/components/games/PacManGame.tsx
+++ b/src/components/games/PacManGame.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Play, Pause, RotateCcw, Zap } from 'lucide-react';
 import { soundManager } from '../../core/SoundManager';
-import { Particle, particleManager } from '../../core/ParticleSystem';
+import { particleManager } from '../../core/ParticleSystem';
 import { FadingCanvas } from "../ui/FadingCanvas";
 import { GameOverBanner } from "../ui/GameOverBanner";
 import { GameProps } from '../../core/GameTypes';
@@ -25,7 +25,6 @@ interface GameRef {
   dots: boolean[][];
   powerPellets: Position[];
   score: number;
-  particles: Particle[];
   frightenedTimer: number;
   level: number;
 }
@@ -131,7 +130,6 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
     
     // Game mechanics
     lastUpdate: 0,
-    particles: [],
     powerPellets: [],
     dotsRemaining: 0,
     modeTimer: 0,
@@ -445,7 +443,7 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
       
       // Dot collection particles
       for (let i = 0; i < 3; i++) {
-        const particle = particleManager.addParticle({
+        particleManager.addParticle({
           x: pacman.x * 20,
           y: pacman.y * 20,
           vx: (Math.random() - 0.5) * 50,
@@ -454,9 +452,6 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
           life: 300,
           size: 2
         });
-        if (particle) {
-          game.particles.push(particle);
-        }
       }
       
       if (settings.sound) {
@@ -479,7 +474,7 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
       
       // Power pellet particles
       for (let i = 0; i < 10; i++) {
-        const particle = particleManager.addParticle({
+        particleManager.addParticle({
           x: pacman.x * 20,
           y: pacman.y * 20,
           vx: (Math.random() - 0.5) * 100,
@@ -488,9 +483,6 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
           life: 800,
           size: 3
         });
-        if (particle) {
-          game.particles.push(particle);
-        }
       }
       
       if (settings.sound) {
@@ -633,7 +625,7 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
           
           // Ghost eaten particles
           for (let i = 0; i < 8; i++) {
-            const particle = particleManager.addParticle({
+            particleManager.addParticle({
               x: ghost.x * 20,
               y: ghost.y * 20,
               vx: (Math.random() - 0.5) * 80,
@@ -642,9 +634,6 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
               life: 500,
               size: 3
             });
-            if (particle) {
-              game.particles.push(particle);
-            }
           }
           
           if (settings.sound) {
@@ -712,7 +701,6 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
       }));
 
       // Clear effects but maintain game progress
-      game.particles = [];
       game.modeTimer = 0;
       game.frightTimer = 0;
       setPowerMode(false);
@@ -725,16 +713,8 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
       console.log(`Level ${level + 1} initialized with increased difficulty`);
     }
 
-    // Update particles with limit to prevent memory leak
-    game.particles = game.particles.filter(particle => {
-      particle.update(deltaTime);
-      return particle.life > 0;
-    });
-    
-    // Limit particle count to prevent memory issues
-    if (game.particles.length > 100) {
-      game.particles = game.particles.slice(-50);
-    }
+    // Update particles
+    particleManager.getParticleSystem().update(deltaTime);
 
     // Render
     const canvas = canvasRef.current;
@@ -855,9 +835,7 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
     });
     
     // Draw particles
-    game.particles.forEach(particle => {
-      particle.draw(ctx);
-    });
+    particleManager.getParticleSystem().draw(ctx);
     
   }, [gameOver, paused, isWalkable, wrapPosition, getGhostTarget, resetMazeToOriginal, settings.sound, score, updateHighScore, level, checkCollisionWithRadius, isAtValidIntersection]);
 
@@ -1248,8 +1226,7 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
       targetHistory: []
     }));
 
-    // 5. Clear all particles and effects
-    game.particles = [];
+    // 5. Clear all effects
 
     // 6. Reset all timers and counters
     game.lastUpdate = 0;
@@ -1270,7 +1247,7 @@ export const PacManGame: React.FC<GameProps> = ({ settings, updateHighScore }) =
       dotsRemaining: game.dotsRemaining,
       pacmanPosition: `${game.pacman.x}, ${game.pacman.y}`,
       ghostCount: game.ghosts.length,
-      particleCount: game.particles.length
+      particleCount: particleManager.getParticleSystem().getParticleCount()
     });
   }, [resetMazeToOriginal, initializeGame]);
 

--- a/src/components/games/PongGame.tsx
+++ b/src/components/games/PongGame.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Play, Pause, RotateCcw } from 'lucide-react';
 import { soundManager } from '../../core/SoundManager';
-import { Particle, particleManager } from '../../core/ParticleSystem';
+import { particleManager } from '../../core/ParticleSystem';
 import { FadingCanvas } from "../ui/FadingCanvas";
 import { GameOverBanner } from "../ui/GameOverBanner";
 import { GameProps } from '../../core/GameTypes';
@@ -25,7 +25,6 @@ interface GameRef {
   playerPaddle: Paddle;
   aiPaddle: Paddle;
   ball: Ball;
-  particles: Particle[];
 }
 
 export const PongGame: React.FC<GameProps> = ({ settings, updateHighScore }) => {
@@ -49,7 +48,6 @@ export const PongGame: React.FC<GameProps> = ({ settings, updateHighScore }) => 
     ballSpeed: 5,
     aiSpeed: settings.difficulty === 'easy' ? 3 : settings.difficulty === 'hard' ? 6 : 4,
     aiReactionTime: settings.difficulty === 'easy' ? 0.8 : settings.difficulty === 'hard' ? 0.95 : 0.9,
-    particles: [],
     paddleHeight: 80,
     paddleWidth: 10,
     ballSize: 10,
@@ -154,7 +152,7 @@ export const PongGame: React.FC<GameProps> = ({ settings, updateHighScore }) => 
 
     const createParticles = (x, y, vx, color) => {
       for (let i = 0; i < 20; i++) {
-        const particle = particleManager.addParticle({
+        particleManager.addParticle({
           x: x,
           y: y,
           vx: vx + (Math.random() - 0.5) * 200,
@@ -163,9 +161,6 @@ export const PongGame: React.FC<GameProps> = ({ settings, updateHighScore }) => 
           life: 0.5,
           size: 2
         });
-        if (particle) {
-          gameRef.current.particles.push(particle);
-        }
       }
     };
 
@@ -299,10 +294,7 @@ export const PongGame: React.FC<GameProps> = ({ settings, updateHighScore }) => 
       }
 
       // Update particles
-      gameRef.current.particles = gameRef.current.particles.filter(p => {
-        p.update(0.016);
-        return p.life > 0;
-      });
+      particleManager.getParticleSystem().update(0.016);
 
       // Draw
       ctx.fillStyle = '#0f172a';
@@ -354,7 +346,7 @@ export const PongGame: React.FC<GameProps> = ({ settings, updateHighScore }) => 
       ctx.shadowBlur = 0;
 
       // Draw particles
-      gameRef.current.particles.forEach(p => p.draw(ctx));
+      particleManager.getParticleSystem().draw(ctx);
 
       // Draw scores
       ctx.font = 'bold 48px monospace';

--- a/src/components/games/SnakeGame.tsx
+++ b/src/components/games/SnakeGame.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Heart, Star, Zap, Shield, Timer, Play, Pause, RotateCcw } from 'lucide-react';
 import { soundManager } from '../../core/SoundManager';
-import { Particle, particleManager } from '../../core/ParticleSystem';
+import { particleManager } from '../../core/ParticleSystem';
 import { FadingCanvas } from "../ui/FadingCanvas";
 import { GameOverBanner } from "../ui/GameOverBanner";
 import { GameProps } from '../../core/GameTypes';
@@ -22,7 +22,6 @@ interface GameRef {
   nextDirection: Position;
   inputBuffer: Position[];
   food: Position;
-  particles: Particle[];
   speed: number;
   lastUpdate: number;
   gridSize: number;
@@ -44,7 +43,6 @@ export const SnakeGame: React.FC<GameProps> = ({ settings, updateHighScore }) =>
     nextDirection: { x: 1, y: 0 },
     inputBuffer: [],
     food: { x: 15, y: 15 },
-    particles: [],
     speed: settings.difficulty === 'easy' ? 150 : settings.difficulty === 'hard' ? 80 : 100,
     lastUpdate: 0,
     gridSize: 20
@@ -198,10 +196,9 @@ export const SnakeGame: React.FC<GameProps> = ({ settings, updateHighScore }) =>
     };
 
     const createParticles = (x, y, color, count = 10) => {
-      const particles = gameRef.current.particles;
       for (let i = 0; i < count; i++) {
         const angle = (Math.PI * 2 * i) / count;
-        const particle = particleManager.addParticle({
+        particleManager.addParticle({
           x: x * (canvas.width / gameRef.current.gridSize) + 10,
           y: y * (canvas.height / gameRef.current.gridSize) + 10,
           vx: Math.cos(angle) * 100,
@@ -210,9 +207,6 @@ export const SnakeGame: React.FC<GameProps> = ({ settings, updateHighScore }) =>
           life: 0.5,
           size: 2
         });
-        if (particle) {
-          particles.push(particle);
-        }
       }
     };
 
@@ -329,15 +323,7 @@ export const SnakeGame: React.FC<GameProps> = ({ settings, updateHighScore }) =>
       }
 
       // Update particles with memory leak prevention
-      gameRef.current.particles = gameRef.current.particles.filter(p => {
-        p.update(0.016);
-        return p.life > 0;
-      });
-      
-      // Prevent memory leak - limit max particles
-      if (gameRef.current.particles.length > 100) {
-        gameRef.current.particles = gameRef.current.particles.slice(-50);
-      }
+      particleManager.getParticleSystem().update(0.016);
 
       // Draw
       ctx.fillStyle = '#0f172a';
@@ -424,7 +410,7 @@ export const SnakeGame: React.FC<GameProps> = ({ settings, updateHighScore }) =>
       });
 
       // Draw particles
-      gameRef.current.particles.forEach(p => p.draw(ctx));
+      particleManager.getParticleSystem().draw(ctx);
 
       animationId = requestAnimationFrame(gameLoop);
     };
@@ -546,7 +532,6 @@ export const SnakeGame: React.FC<GameProps> = ({ settings, updateHighScore }) =>
       nextDirection: { x: 1, y: 0 },
       inputBuffer: [],
       food: { x: 15, y: 15 },
-      particles: [],
       speed: settings.difficulty === 'easy' ? 150 : settings.difficulty === 'hard' ? 80 : 100,
       lastUpdate: 0,
       gridSize: 20

--- a/src/components/games/SpaceInvadersGame.tsx
+++ b/src/components/games/SpaceInvadersGame.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Heart, Play, Pause, RotateCcw } from 'lucide-react';
 import { soundManager } from '../../core/SoundManager';
-import { Particle, particleManager } from '../../core/ParticleSystem';
+import { particleManager } from '../../core/ParticleSystem';
 import { GameProps } from '../../core/GameTypes';
 
 interface Enemy {
@@ -27,7 +27,6 @@ interface GameRef {
   aliens: Enemy[];
   barriers: any[];
   powerUps: any[];
-  particles: Particle[];
   alienDirection: number;
   lastShot: number;
   alienShootTimer: number;
@@ -49,7 +48,6 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
     aliens: [],
     barriers: [],
     powerUps: [],
-    particles: [],
     lastUpdate: 0,
     alienDirection: 1,
     alienSpeed: 1,
@@ -347,7 +345,7 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
             
             // Create enhanced particles
             for (let i = 0; i < 15; i++) {
-              const particle = particleManager.addParticle({
+              particleManager.addParticle({
                 x: alien.x + alien.width / 2,
                 y: alien.y + alien.height / 2,
                 vx: Math.random() * 8 - 4,
@@ -356,9 +354,6 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
                 life: 60,
                 size: 2
               });
-              if (particle) {
-                game.particles.push(particle);
-              }
             }
             
             soundManager.playHit();
@@ -395,7 +390,7 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
           
           // Create particles
           for (let i = 0; i < 10; i++) {
-            const particle = particleManager.addParticle({
+            particleManager.addParticle({
               x: powerUpItem.x + powerUpItem.width / 2,
               y: powerUpItem.y + powerUpItem.height / 2,
               vx: Math.random() * 6 - 3,
@@ -404,9 +399,6 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
               life: 30,
               size: 2
             });
-            if (particle) {
-              game.particles.push(particle);
-            }
           }
           
           return false;
@@ -442,7 +434,7 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
             
             // Create particles
             for (let i = 0; i < 12; i++) {
-              const particle = particleManager.addParticle({
+              particleManager.addParticle({
                 x: game.player.x + game.player.width / 2,
                 y: game.player.y + game.player.height / 2,
                 vx: Math.random() * 6 - 3,
@@ -451,9 +443,6 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
                 life: 40,
                 size: 2
               });
-              if (particle) {
-                game.particles.push(particle);
-              }
             }
           }
         }
@@ -477,7 +466,7 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
             
             // Create particles
             for (let i = 0; i < 4; i++) {
-              const particle = particleManager.addParticle({
+              particleManager.addParticle({
                 x: bullet.x,
                 y: bullet.y,
                 vx: Math.random() * 4 - 2,
@@ -486,19 +475,13 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
                 life: 20,
                 size: 2
               });
-              if (particle) {
-                game.particles.push(particle);
-              }
             }
           }
         });
       });
 
       // Update particles
-      game.particles = game.particles.filter(particle => {
-        particle.update();
-        return particle.life > 0;
-      });
+      particleManager.getParticleSystem().update();
 
       // Check win condition
       if (aliveAliens.length === 0) {
@@ -650,9 +633,7 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
       });
 
       // Draw particles
-      game.particles.forEach(particle => {
-        particle.render(ctx);
-      });
+      particleManager.getParticleSystem().draw(ctx);
 
       animationId = requestAnimationFrame(gameLoop);
     };
@@ -687,7 +668,6 @@ export const SpaceInvadersGame: React.FC<GameProps> = ({ settings, updateHighSco
     game.player.x = 400;
     game.bullets = [];
     game.alienBullets = [];
-    game.particles = [];
     game.powerUps = [];
     game.alienDirection = 1;
     game.alienSpeed = 1;

--- a/src/components/games/StellarDriftGame.tsx
+++ b/src/components/games/StellarDriftGame.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Play, Pause, RotateCcw, Shield } from 'lucide-react';
 import { soundManager } from '../../core/SoundManager';
-import { Particle } from '../../core/ParticleSystem';
+import { particleManager } from '../../core/ParticleSystem';
 import { FadingCanvas } from "../ui/FadingCanvas";
 import { GameOverBanner } from "../ui/GameOverBanner";
 import { GameProps } from '../../core/GameTypes';
@@ -36,7 +36,6 @@ interface GameRef {
   bullets: any[];
   powerUps: any[];
   stars: any[];
-  particles: Particle[];
   lastShot: number;
   animationFrame?: number;
 }
@@ -77,7 +76,6 @@ export const StellarDriftGame: React.FC<GameProps> = ({ settings, updateHighScor
     minTunnelGap: 140, // Minimum gap for mobile comfort
     
     // Game state
-    particles: [],
     obstacles: [],
     comets: [],
     lastUpdate: 0,
@@ -287,7 +285,7 @@ export const StellarDriftGame: React.FC<GameProps> = ({ settings, updateHighScor
 
     // Add explosion particles
     for (let i = 0; i < 10; i++) {
-      const particle = particleManager.addParticle({
+      particleManager.addParticle({
         x: game.pod.x + game.pod.width / 2,
         y: game.pod.y + game.pod.height / 2,
         vx: (Math.random() - 0.5) * 200,
@@ -296,9 +294,6 @@ export const StellarDriftGame: React.FC<GameProps> = ({ settings, updateHighScor
         life: 1000 + Math.random() * 500,
         size: 2
       });
-      if (particle) {
-        game.particles.push(particle);
-      }
     }
   }, [settings.sound, score, updateHighScore]);
 
@@ -428,10 +423,7 @@ export const StellarDriftGame: React.FC<GameProps> = ({ settings, updateHighScor
     });
 
     // Update particles
-    game.particles = game.particles.filter(particle => {
-      particle.update(deltaTime);
-      return particle.life > 0;
-    });
+    particleManager.getParticleSystem().update(deltaTime);
 
     // Collision detection
     const podRect = {
@@ -685,7 +677,7 @@ export const StellarDriftGame: React.FC<GameProps> = ({ settings, updateHighScor
       
       // Thrust particles when active
       if (game.thrustActive && Math.random() < 0.7) {
-        const particle = particleManager.addParticle({
+        particleManager.addParticle({
           x: shipX - 8 + Math.random() * 4,
           y: shipY + (Math.random() - 0.5) * 4,
           vx: -100 - Math.random() * 50,
@@ -694,9 +686,6 @@ export const StellarDriftGame: React.FC<GameProps> = ({ settings, updateHighScor
           life: 200 + Math.random() * 200,
           size: 2
         });
-        if (particle) {
-          game.particles.push(particle);
-        }
       }
       
       // Wing details
@@ -711,13 +700,9 @@ export const StellarDriftGame: React.FC<GameProps> = ({ settings, updateHighScor
     drawPlayerShip();
 
     // Draw particles with glow
-    game.particles.forEach(particle => {
-      ctx.save();
-      ctx.shadowColor = particle.color;
-      ctx.shadowBlur = 8;
-      particle.draw(ctx);
-      ctx.restore();
-    });
+    ctx.save();
+    particleManager.getParticleSystem().draw(ctx);
+    ctx.restore();
 
     // Enhanced speed lines with glow
     if (game.scrollSpeed > 150) {
@@ -864,7 +849,6 @@ export const StellarDriftGame: React.FC<GameProps> = ({ settings, updateHighScor
     game.scrollSpeed = 120;
     game.worldX = 0;
     game.chunks = [];
-    game.particles = [];
     game.obstacles = [];
     game.comets = [];
     game.invulnerabilityTime = 0;


### PR DESCRIPTION
## Summary
- simplify particle spawning in BreakoutGame, SnakeGame, PongGame, PacManGame, SpaceInvadersGame and StellarDriftGame
- rely on global particle manager for updating and drawing effects

## Testing
- `npm run build`