### PR TITLE
Standardize canvas sizing

### DIFF
--- a/ENHANCEMENT_NOTES.md
+++ b/ENHANCEMENT_NOTES.md
@@ -163,3 +163,4 @@ const getThemeForLevel = (level: number) => {
 - Game systems should extend existing core modules
 - Use existing hooks pattern for state management
 - Maintain TypeScript interfaces throughout
+- Canvas sizing is centralized in `src/core/CanvasConfig.ts` and used with `ResponsiveCanvas`

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ If upgrading from the old monolithic version (prior to modular architecture):
 - Check Tailwind CSS responsive classes
 - Test landscape/portrait orientation changes
 - Use ResponsiveCanvas component for consistent scaling
+- Define base canvas sizes in `src/core/CanvasConfig.ts` and import values in each game
 - Check viewport meta tag configuration
 
 **Port conflicts:**

--- a/src/components/games/BreakoutGame.tsx
+++ b/src/components/games/BreakoutGame.tsx
@@ -4,6 +4,8 @@ import { soundManager } from '../../core/SoundManager';
 import { Particle } from '../../core/ParticleSystem';
 import { FadingCanvas } from "../ui/FadingCanvas";
 import { GameOverBanner } from "../ui/GameOverBanner";
+import { ResponsiveCanvas } from "../ui/ResponsiveCanvas";
+import { CANVAS_CONFIG } from "../../core/CanvasConfig";
 
 // Interfaces
 interface Ball {
@@ -157,13 +159,8 @@ export const BreakoutGame: React.FC<BreakoutGameProps> = ({ settings, updateHigh
     
     let animationId: number;
     
-    const resizeCanvas = () => {
-      canvas.width = Math.min(window.innerWidth - 32, 800);
-      canvas.height = 600;
-    };
-    
-    resizeCanvas();
-    window.addEventListener('resize', resizeCanvas);
+    canvas.width = 800;
+    canvas.height = 600;
 
     const handleBlur = () => setPaused(true);
     const handleFocus = () => setPaused(false);
@@ -411,7 +408,6 @@ export const BreakoutGame: React.FC<BreakoutGameProps> = ({ settings, updateHigh
       canvas.removeEventListener('mousemove', handleMouseMove);
       canvas.removeEventListener('touchmove', handleTouchMove);
       window.removeEventListener('keydown', handleKeyboard);
-      window.removeEventListener('resize', resizeCanvas);
       window.removeEventListener('blur', handleBlur);
       window.removeEventListener('focus', handleFocus);
     };
@@ -458,12 +454,17 @@ export const BreakoutGame: React.FC<BreakoutGameProps> = ({ settings, updateHigh
         </div>
       </div>
       
-      <FadingCanvas active={!gameOver && !transitioning} slide={transitioning}>
-        <canvas
-          ref={canvasRef}
-          className="border-2 border-red-500 rounded-lg shadow-lg shadow-red-500/50 cursor-none touch-none"
-        />
-      </FadingCanvas>
+      <ResponsiveCanvas
+        width={CANVAS_CONFIG.breakout.width}
+        height={CANVAS_CONFIG.breakout.height}
+      >
+        <FadingCanvas active={!gameOver && !transitioning} slide={transitioning}>
+          <canvas
+            ref={canvasRef}
+            className="border-2 border-red-500 rounded-lg shadow-lg shadow-red-500/50 cursor-none touch-none"
+          />
+        </FadingCanvas>
+      </ResponsiveCanvas>
       <GameOverBanner show={gameOver} />
       
       <div className="mt-4 flex gap-2">

--- a/src/components/games/PacManGame.tsx
+++ b/src/components/games/PacManGame.tsx
@@ -4,6 +4,8 @@ import { soundManager } from '../../core/SoundManager';
 import { Particle } from '../../core/ParticleSystem';
 import { FadingCanvas } from '../ui/FadingCanvas';
 import { GameOverBanner } from '../ui/GameOverBanner';
+import { ResponsiveCanvas } from "../ui/ResponsiveCanvas";
+import { CANVAS_CONFIG } from "../../core/CanvasConfig";
 
 // TypeScript interfaces
 interface Position {
@@ -403,12 +405,8 @@ export const PacManGame: React.FC<PacManGameProps> = ({ settings, updateHighScor
     
     let animationId: number;
     
-    const resizeCanvas = () => {
-      canvas.width = MAZE_WIDTH * CELL_SIZE;
-      canvas.height = MAZE_HEIGHT * CELL_SIZE;
-    };
-    
-    resizeCanvas();
+    canvas.width = CANVAS_CONFIG.pacman.width;
+    canvas.height = CANVAS_CONFIG.pacman.height;
     initializeGame();
     
     const gameLoop = (timestamp: number) => {
@@ -1062,11 +1060,12 @@ export const PacManGame: React.FC<PacManGameProps> = ({ settings, updateHighScor
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-900 p-4">
       <div className="relative bg-black rounded-lg shadow-2xl overflow-hidden">
-        <FadingCanvas 
-          ref={canvasRef} 
-          width={MAZE_WIDTH * CELL_SIZE}
-          height={MAZE_HEIGHT * CELL_SIZE}
-        />
+        <ResponsiveCanvas
+          width={CANVAS_CONFIG.pacman.width}
+          height={CANVAS_CONFIG.pacman.height}
+        >
+          <FadingCanvas ref={canvasRef} />
+        </ResponsiveCanvas>
         
         {gameOver && <GameOverBanner score={score} onRestart={resetGame} />}
         

--- a/src/components/games/PongGame.tsx
+++ b/src/components/games/PongGame.tsx
@@ -4,6 +4,8 @@ import { soundManager } from '../../core/SoundManager';
 import { Particle } from '../../core/ParticleSystem';
 import { FadingCanvas } from "../ui/FadingCanvas";
 import { GameOverBanner } from "../ui/GameOverBanner";
+import { ResponsiveCanvas } from "../ui/ResponsiveCanvas";
+import { CANVAS_CONFIG } from "../../core/CanvasConfig";
 
 
 
@@ -90,13 +92,8 @@ export const PongGame: React.FC<PongGameProps> = ({ settings, updateHighScore })
     
     let animationId: number;
     
-    const resizeCanvas = (): void => {
-      canvas.width = Math.min(window.innerWidth - 32, 800);
-      canvas.height = 400;
-    };
-    
-    resizeCanvas();
-    window.addEventListener('resize', resizeCanvas);
+    canvas.width = 800;
+    canvas.height = 400;
 
     const handleBlur = (): void => setPaused(true);
     const handleFocus = (): void => setPaused(false);
@@ -322,7 +319,6 @@ export const PongGame: React.FC<PongGameProps> = ({ settings, updateHighScore })
       canvas.removeEventListener('mousemove', handleMouseMove);
       canvas.removeEventListener('touchmove', handleTouchMove);
       window.removeEventListener('keydown', handleKeyboard);
-      window.removeEventListener('resize', resizeCanvas);
       window.removeEventListener('blur', handleBlur);
       window.removeEventListener('focus', handleFocus);
     };
@@ -404,12 +400,17 @@ export const PongGame: React.FC<PongGameProps> = ({ settings, updateHighScore })
         <span className={`text-red-400 transition-transform ${aiFlash ? 'scale-125' : ''}`}>{aiScore}</span>
       </div>
 
-      <FadingCanvas active={!gameOver}>
-        <canvas
-          ref={canvasRef}
-          className="border-2 border-blue-500 rounded-lg shadow-lg shadow-blue-500/50 cursor-none touch-none"
-        />
-      </FadingCanvas>
+      <ResponsiveCanvas
+        width={CANVAS_CONFIG.pong.width}
+        height={CANVAS_CONFIG.pong.height}
+      >
+        <FadingCanvas active={!gameOver}>
+          <canvas
+            ref={canvasRef}
+            className="border-2 border-blue-500 rounded-lg shadow-lg shadow-blue-500/50 cursor-none touch-none"
+          />
+        </FadingCanvas>
+      </ResponsiveCanvas>
       <GameOverBanner show={gameOver} />
       
       <div className="mt-4 flex gap-2">

--- a/src/components/games/SnakeGame.tsx
+++ b/src/components/games/SnakeGame.tsx
@@ -4,6 +4,8 @@ import { soundManager } from '../../core/SoundManager';
 import { Particle } from '../../core/ParticleSystem';
 import { FadingCanvas } from "../ui/FadingCanvas";
 import { GameOverBanner } from "../ui/GameOverBanner";
+import { ResponsiveCanvas } from "../ui/ResponsiveCanvas";
+import { CANVAS_CONFIG } from "../../core/CanvasConfig";
 
 interface Position {
   x: number;
@@ -75,14 +77,8 @@ export const SnakeGame: React.FC<SnakeGameProps> = ({ settings, updateHighScore 
     if (!ctx) return;
     let animationId: number;
     
-    const resizeCanvas = () => {
-      const size = Math.min(window.innerWidth - 32, 400);
-      canvas.width = size;
-      canvas.height = size;
-    };
-    
-    resizeCanvas();
-    window.addEventListener('resize', resizeCanvas);
+    canvas.width = 400;
+    canvas.height = 400;
 
     const handleBlur = () => setPaused(true);
     const handleFocus = () => setPaused(false);
@@ -358,7 +354,6 @@ export const SnakeGame: React.FC<SnakeGameProps> = ({ settings, updateHighScore 
         speedTimeoutRef.current = null;
       }
       window.removeEventListener('keydown', handleInput);
-      window.removeEventListener('resize', resizeCanvas);
       window.removeEventListener('blur', handleBlur);
       window.removeEventListener('focus', handleFocus);
     };
@@ -488,15 +483,20 @@ export const SnakeGame: React.FC<SnakeGameProps> = ({ settings, updateHighScore 
         )}
       </div>
       
-      <FadingCanvas active={!gameOver}>
-        <canvas
-          ref={canvasRef}
-          onTouchStart={handleTouchStart}
-          onTouchMove={handleTouchMove}
-          onTouchEnd={handleTouchEnd}
-          className="border-2 border-green-500 rounded-lg shadow-lg shadow-green-500/50 touch-none"
-        />
-      </FadingCanvas>
+      <ResponsiveCanvas
+        width={CANVAS_CONFIG.snake.width}
+        height={CANVAS_CONFIG.snake.height}
+      >
+        <FadingCanvas active={!gameOver}>
+          <canvas
+            ref={canvasRef}
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={handleTouchEnd}
+            className="border-2 border-green-500 rounded-lg shadow-lg shadow-green-500/50 touch-none"
+          />
+        </FadingCanvas>
+      </ResponsiveCanvas>
       <GameOverBanner show={gameOver} />
       
       <div className="mt-4 flex gap-2">

--- a/src/components/games/SpaceInvadersGame.tsx
+++ b/src/components/games/SpaceInvadersGame.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Heart, Play, Pause, RotateCcw } from 'lucide-react';
 import { soundManager } from '../../core/SoundManager';
 import { Particle } from '../../core/ParticleSystem';
+import { ResponsiveCanvas } from "../ui/ResponsiveCanvas";
+import { CANVAS_CONFIG } from "../../core/CanvasConfig";
 
 
 
@@ -155,13 +157,8 @@ export const SpaceInvadersGame: React.FC<SpaceInvadersGameProps> = ({ settings, 
     
     let animationId: number;
     
-    const resizeCanvas = () => {
-      canvas.width = Math.min(window.innerWidth - 32, 800);
-      canvas.height = 600;
-    };
-    
-    resizeCanvas();
-    window.addEventListener('resize', resizeCanvas);
+    canvas.width = CANVAS_CONFIG.spaceInvaders.width;
+    canvas.height = CANVAS_CONFIG.spaceInvaders.height;
 
     const handleBlur = () => setPaused(true);
     const handleFocus = () => setPaused(false);
@@ -735,7 +732,6 @@ export const SpaceInvadersGame: React.FC<SpaceInvadersGameProps> = ({ settings, 
       }
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
-      window.removeEventListener('resize', resizeCanvas);
       window.removeEventListener('blur', handleBlur);
       window.removeEventListener('focus', handleFocus);
       canvas.removeEventListener('mousemove', handleMouseMove);
@@ -808,11 +804,16 @@ export const SpaceInvadersGame: React.FC<SpaceInvadersGameProps> = ({ settings, 
           </div>
         </div>
         
-        <canvas
-          ref={canvasRef}
-          className="border-2 border-gray-600 rounded-lg bg-black mx-auto block"
-          style={{ maxWidth: '100%', height: 'auto' }}
-        />
+        <ResponsiveCanvas
+          width={CANVAS_CONFIG.spaceInvaders.width}
+          height={CANVAS_CONFIG.spaceInvaders.height}
+        >
+          <canvas
+            ref={canvasRef}
+            className="border-2 border-gray-600 rounded-lg bg-black mx-auto block"
+            style={{ maxWidth: '100%', height: 'auto' }}
+          />
+        </ResponsiveCanvas>
         
         <div className="mt-4 text-center text-sm text-gray-400">
           <p>Arrow Keys/WASD to move • Mouse/Touch to follow • Hold Space/Click to auto-fire • P to pause</p>

--- a/src/components/games/TetrisGame.tsx
+++ b/src/components/games/TetrisGame.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Heart, Play, Pause, RotateCcw } from 'lucide-react';
 import { soundManager } from '../../core/SoundManager';
 import { Particle } from '../../core/ParticleSystem';
+import { ResponsiveCanvas } from "../ui/ResponsiveCanvas";
+import { CANVAS_CONFIG } from "../../core/CanvasConfig";
 
 
 
@@ -469,13 +471,8 @@ export const TetrisGame: React.FC<TetrisGameProps> = ({ settings, updateHighScor
     
     let animationId: number;
     
-    const resizeCanvas = () => {
-      canvas.width = BOARD_WIDTH * CELL_SIZE + 200; // Extra space for UI
-      canvas.height = BOARD_HEIGHT * CELL_SIZE;
-    };
-    
-    resizeCanvas();
-    window.addEventListener('resize', resizeCanvas);
+    canvas.width = CANVAS_CONFIG.tetris.width;
+    canvas.height = CANVAS_CONFIG.tetris.height;
 
     const handleBlur = () => setPaused(true);
     const handleFocus = () => setPaused(false);
@@ -916,7 +913,6 @@ export const TetrisGame: React.FC<TetrisGameProps> = ({ settings, updateHighScor
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
-      window.removeEventListener('resize', resizeCanvas);
       window.removeEventListener('blur', handleBlur);
       window.removeEventListener('focus', handleFocus);
       canvas.removeEventListener('touchstart', handleTouchStart);
@@ -980,11 +976,16 @@ export const TetrisGame: React.FC<TetrisGameProps> = ({ settings, updateHighScor
           </div>
         </div>
         
-        <canvas
-          ref={canvasRef}
-          className="border-2 border-gray-600 rounded-lg bg-black mx-auto block"
-          style={{ maxWidth: '100%', height: 'auto' }}
-        />
+        <ResponsiveCanvas
+          width={CANVAS_CONFIG.tetris.width}
+          height={CANVAS_CONFIG.tetris.height}
+        >
+          <canvas
+            ref={canvasRef}
+            className="border-2 border-gray-600 rounded-lg bg-black mx-auto block"
+            style={{ maxWidth: '100%', height: 'auto' }}
+          />
+        </ResponsiveCanvas>
         
         <div className="mt-4 text-center text-sm text-gray-400">
           <p>Arrow Keys/WASD to move • Tap to rotate • Swipe down to drop</p>

--- a/src/core/CanvasConfig.ts
+++ b/src/core/CanvasConfig.ts
@@ -1,0 +1,14 @@
+export interface CanvasSize {
+  width: number;
+  height: number;
+}
+
+export const CANVAS_CONFIG: Record<string, CanvasSize> = {
+  snake: { width: 400, height: 400 },
+  pong: { width: 800, height: 400 },
+  breakout: { width: 800, height: 600 },
+  tetris: { width: 10 * 25 + 200, height: 20 * 25 },
+  spaceInvaders: { width: 800, height: 600 },
+  pacman: { width: 28 * 20, height: 31 * 20 },
+  menu: { width: 800, height: 600 }
+};


### PR DESCRIPTION
## Summary
- add `CanvasConfig` for centralized canvas dimensions
- wrap all game canvases in `ResponsiveCanvas`
- remove custom resize handlers
- document centralized canvas sizing in README and notes

## Testing
- `./codex-setup.sh`
- `npm run build`
