### PR TITLE
Fix glowData size property

### DIFF
--- a/src/components/games/NeonJumpGame.tsx
+++ b/src/components/games/NeonJumpGame.tsx
@@ -10929,7 +10929,7 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
       // Add missing properties for backward compatibility
       afterimageTrail: [],
       motionBlur: { enabled: false, intensity: 0, samples: [] },
-      glowData: { intensity: 1, color: '#ffffff', radius: 10 },
+      glowData: { intensity: 1, color: '#ffffff', size: 10 },
       shield: false,
       lives: 3,
       x: 200,


### PR DESCRIPTION
## Summary
- rename leftover `radius` property of `glowData` to `size` in NeonJumpGame

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683b5f25fab4832e8935e237e5a9be38