### PR TITLE
Fix saveData scope and add localStorage checks

### DIFF
--- a/src/components/games/NeonJumpGame copy.tsx
+++ b/src/components/games/NeonJumpGame copy.tsx
@@ -10883,8 +10883,7 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
     }
   }, []);
 
-  const saveGameData = useCallback(async () => {
-    const game = gameRef.current;
+  const saveGameData = useCallback(async (game: GameState) => {
     
     // CRITICAL FIX: Acquire lock before saving to prevent corruption
     if (!await acquireStorageLock()) {
@@ -10892,9 +10891,10 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
       return;
     }
     
+    let saveData: any;
     try {
       // Sanitize data before saving
-      const saveData = {
+      saveData = {
         totalCoins: Math.max(0, Math.min(999999, Math.floor(game.totalCoins))),
         upgrades: {
           jumpHeight: Math.max(0, Math.min(5, Math.floor(game.upgrades.jumpHeight || 0))),
@@ -10917,8 +10917,10 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
       if (e.name === 'QuotaExceededError') {
         try {
           localStorage.removeItem('neonJump_saveData_old');
-          const serialized = JSON.stringify(saveData);
-          localStorage.setItem('neonJump_saveData', serialized);
+          if (saveData) {
+            const serialized = JSON.stringify(saveData);
+            localStorage.setItem('neonJump_saveData', serialized);
+          }
         } catch (e2) {
           console.error('Still cannot save after cleanup:', e2);
           // Could show user notification here
@@ -10985,12 +10987,13 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
     return true;
   }, []);
 
-  const loadGameData = useCallback(() => {
-    const game = gameRef.current;
+  const loadGameData = useCallback((game: GameState) => {
     try {
       const savedData = localStorage.getItem('neonJump_saveData');
-      if (savedData) {
-        const data = JSON.parse(savedData);
+      if (savedData == null) {
+        return;
+      }
+      const data = JSON.parse(savedData);
         
         // Validate save data
         if (!validateSaveData(data)) {
@@ -11021,7 +11024,6 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
           game.player.position.y -= startingHeight;
           game.camera.y = -startingHeight + CAMERA_LOOK_AHEAD;
         }
-      }
     } catch (e) {
       console.error('Failed to load save data:', e);
       // Initialize with defaults
@@ -11074,7 +11076,7 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
     }
     
     // Save data
-    saveGameData();
+    saveGameData(game);
     
     // Force re-render
     setShowShop(false);
@@ -11297,7 +11299,7 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
     
     // Initialize game
     initializePlatforms();
-    loadGameData();
+    loadGameData(gameRef.current);
     
     // Canvas context loss handling
     const handleContextLost = (e: Event) => {
@@ -11442,7 +11444,7 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
     
     // Save game data when game ends
     if (gameOver) {
-      saveGameData();
+      saveGameData(gameRef.current);
     }
   }, [score, highScore, updateHighScore, gameOver, saveGameData]);
 


### PR DESCRIPTION
## Summary
- fix NeonJump saveGameData to define saveData outside try/catch
- add null checks when loading from storage
- pass game objects into helper save/load functions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683b5f300f4c832e90511aa5c9268e90