### PR TITLE
Integrate WASM physics layer

### DIFF
--- a/src/core/PhysicsWASM.ts
+++ b/src/core/PhysicsWASM.ts
@@ -1,0 +1,68 @@
+export type PhysicsExports = {
+  integrate_position: (x: number, vx: number, dt: number) => number;
+  integrate_velocity: (v: number, a: number, dt: number) => number;
+  detect_collision: (
+    ax: number,
+    ay: number,
+    aw: number,
+    ah: number,
+    bx: number,
+    by: number,
+    bw: number,
+    bh: number
+  ) => number;
+};
+
+let wasm: PhysicsExports | null = null;
+
+const fallback = {
+  integrate_position: (x: number, vx: number, dt: number) => x + vx * dt,
+  integrate_velocity: (v: number, a: number, dt: number) => v + a * dt,
+  detect_collision: (
+    ax: number,
+    ay: number,
+    aw: number,
+    ah: number,
+    bx: number,
+    by: number,
+    bw: number,
+    bh: number
+  ) => (ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by ? 1 : 0),
+};
+
+export async function initPhysicsWASM(): Promise<void> {
+  try {
+    const response = await fetch('/physics_wasm.wasm');
+    if (!response.ok) throw new Error('Failed to fetch wasm');
+    const bytes = await response.arrayBuffer();
+    const result = await WebAssembly.instantiate(bytes, {});
+    wasm = result.instance.exports as unknown as PhysicsExports;
+  } catch (err) {
+    console.warn('Physics WASM failed to load, falling back to JS', err);
+    wasm = null;
+  }
+}
+
+export const integratePosition = (
+  x: number,
+  vx: number,
+  dt: number
+): number => (wasm ? wasm.integrate_position(x, vx, dt) : fallback.integrate_position(x, vx, dt));
+
+export const integrateVelocity = (
+  v: number,
+  a: number,
+  dt: number
+): number => (wasm ? wasm.integrate_velocity(v, a, dt) : fallback.integrate_velocity(v, a, dt));
+
+export const detectCollision = (
+  ax: number,
+  ay: number,
+  aw: number,
+  ah: number,
+  bx: number,
+  by: number,
+  bw: number,
+  bh: number
+): boolean =>
+  (wasm ? wasm.detect_collision(ax, ay, aw, ah, bx, by, bw, bh) : fallback.detect_collision(ax, ay, aw, ah, bx, by, bw, bh)) === 1;

--- a/wasm/physics/Cargo.toml
+++ b/wasm/physics/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "physics_wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = "z"
+

--- a/wasm/physics/README.md
+++ b/wasm/physics/README.md
@@ -1,0 +1,15 @@
+# Physics WASM Module
+
+This Rust crate provides basic physics integration and collision detection routines for `NeonJumpGame`.
+
+## Building
+
+To compile the WebAssembly module run:
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+```
+
+The resulting `physics_wasm.wasm` file can be copied to `public/physics_wasm.wasm`.
+
+Note: In the Codex environment network access is disabled after setup so the `wasm32-unknown-unknown` target may not be installed. Make sure it is installed locally via `rustup target add wasm32-unknown-unknown` before running the build.

--- a/wasm/physics/src/lib.rs
+++ b/wasm/physics/src/lib.rs
@@ -1,0 +1,24 @@
+#[no_mangle]
+pub extern "C" fn integrate_position(x: f32, vx: f32, dt: f32) -> f32 {
+    x + vx * dt
+}
+
+#[no_mangle]
+pub extern "C" fn integrate_velocity(v: f32, a: f32, dt: f32) -> f32 {
+    v + a * dt
+}
+
+#[no_mangle]
+pub extern "C" fn detect_collision(
+    ax: f32,
+    ay: f32,
+    aw: f32,
+    ah: f32,
+    bx: f32,
+    by: f32,
+    bw: f32,
+    bh: f32,
+) -> i32 {
+    let collision = ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+    if collision { 1 } else { 0 }
+}


### PR DESCRIPTION
## Summary
- add Rust crate `physics_wasm` with simple physics helpers
- expose WASM integration helpers via `PhysicsWASM.ts`
- load the WASM module in `NeonJumpGame` and use it for particle physics and platform collisions
- include placeholder `public/physics_wasm.wasm`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683b8d132480832eb542645def8c09b7