### PR TITLE
Add procedural music system and music volume setting

### DIFF
--- a/src/components/ui/SettingsModal.tsx
+++ b/src/components/ui/SettingsModal.tsx
@@ -4,6 +4,7 @@ import { Volume2, VolumeX } from 'lucide-react';
 interface Settings {
   soundEnabled: boolean;
   volume: number;
+  musicVolume: number;
   difficulty: string;
 }
 
@@ -38,6 +39,19 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onSettin
             step="0.1"
             value={settings.volume}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => onSettingsChange({ ...settings, volume: parseFloat(e.target.value) })}
+            className="w-32"
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <label className="text-white">Music Volume</label>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.1"
+            value={settings.musicVolume}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onSettingsChange({ ...settings, musicVolume: parseFloat(e.target.value) })}
             className="w-32"
           />
         </div>

--- a/src/core/GameTypes.ts
+++ b/src/core/GameTypes.ts
@@ -1,6 +1,7 @@
 export interface GameSettings {
   soundEnabled: boolean;
   volume: number;
+  musicVolume: number;
   difficulty: 'easy' | 'normal' | 'hard';
   theme: string;
 }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -3,6 +3,7 @@ import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 export interface GameSettings {
   soundEnabled: boolean;
   volume: number;
+  musicVolume: number;
   difficulty: 'easy' | 'normal' | 'hard';
   theme: 'neon' | 'retro' | 'minimal';
 }
@@ -12,6 +13,7 @@ export type UseSettingsReturn = [GameSettings, Dispatch<SetStateAction<GameSetti
 const DEFAULT_SETTINGS: GameSettings = {
   soundEnabled: true,
   volume: 0.5,
+  musicVolume: 0.6,
   difficulty: 'normal',
   theme: 'neon'
 };
@@ -33,9 +35,15 @@ const validateSettings = (data: unknown): GameSettings | null => {
       return null;
     }
 
-    if (typeof settings.volume !== 'number' || 
-        settings.volume < 0 || 
+    if (typeof settings.volume !== 'number' ||
+        settings.volume < 0 ||
         settings.volume > 1) {
+      return null;
+    }
+
+    if (typeof settings.musicVolume !== 'number' ||
+        settings.musicVolume < 0 ||
+        settings.musicVolume > 1) {
       return null;
     }
 
@@ -50,6 +58,7 @@ const validateSettings = (data: unknown): GameSettings | null => {
     return {
       soundEnabled: settings.soundEnabled,
       volume: settings.volume,
+      musicVolume: settings.musicVolume,
       difficulty: settings.difficulty as 'easy' | 'normal' | 'hard',
       theme: settings.theme as 'neon' | 'retro' | 'minimal'
     };


### PR DESCRIPTION
## Summary
- extend `GameSettings` with `musicVolume`
- validate and persist new setting in `useSettings`
- expose music volume slider in `SettingsModal`
- update NeonJump audio levels to use settings
- add `ProceduralMusic` generator to `SoundManager`
- manage music layers based on intensity in `MusicManager`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683b8d186b04832e935264607182d910