### PR TITLE
Extract Pac‑Man types

### DIFF
--- a/src/components/games/PacManGame.tsx
+++ b/src/components/games/PacManGame.tsx
@@ -2,107 +2,19 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Play, Pause, RotateCcw, Zap, Shield } from 'lucide-react';
 import { soundManager } from '../../core/SoundManager';
 import { Particle } from '../../core/ParticleSystem';
+import type {
+  Position,
+  GridPosition,
+  Ghost,
+  PowerUp,
+  Direction,
+  GameState,
+  PacManGameProps
+} from './pacman/types';
 import { FadingCanvas } from '../ui/FadingCanvas';
 import { GameOverBanner } from '../ui/GameOverBanner';
 import { ResponsiveCanvas } from "../ui/ResponsiveCanvas";
 import { CANVAS_CONFIG } from "../../core/CanvasConfig";
-
-// TypeScript interfaces
-interface Position {
-  x: number;
-  y: number;
-}
-
-interface GridPosition {
-  row: number;
-  col: number;
-}
-
-interface Ghost {
-  id: string;
-  position: Position;
-  gridPos: GridPosition;
-  targetGridPos: GridPosition;
-  color: string;
-  mode: 'chase' | 'scatter' | 'frightened' | 'eaten' | 'in_house' | 'exiting';
-  speed: number;
-  aiType: 'blinky' | 'pinky' | 'inky' | 'clyde';
-  direction: Direction;
-  scatterTarget: GridPosition;
-  exitTimer: number;
-}
-
-interface PowerUp {
-  type: 'speed' | 'freeze' | 'magnet' | 'shield';
-  gridPos: GridPosition;
-  duration: number;
-  icon: string;
-}
-
-type Direction = 'up' | 'down' | 'left' | 'right' | 'none';
-
-interface GameState {
-  pacman: {
-    position: Position;
-    gridPos: GridPosition;
-    targetGridPos: GridPosition;
-    previousGridPos: GridPosition;
-    direction: Direction;
-    nextDirection: Direction;
-    speed: number;
-    mouthOpen: boolean;
-    mouthTimer: number;
-    powerUpActive: string | null;
-    powerUpTimer: number;
-    invincibleTimer: number;
-    shieldHits: number;
-  };
-  ghosts: Ghost[];
-  maze: number[][];
-  pellets: Set<string>;
-  powerPellets: Set<string>;
-  powerUps: Map<string, PowerUp>;
-  score: number;
-  lives: number;
-  level: number;
-  combo: number;
-  comboTimer: number;
-  particles: Particle[];
-  gamePhase: 'ready' | 'playing' | 'levelComplete' | 'gameOver' | 'dying';
-  frightenedTimer: number;
-  freezeTimer: number;
-  lastUpdate: number;
-  mazeCacheCanvas: HTMLCanvasElement | null;
-  mazeCacheCtx: CanvasRenderingContext2D | null;
-  mazeCacheDirty: boolean;
-  pelletCacheCanvas: HTMLCanvasElement | null;
-  pelletCacheCtx: CanvasRenderingContext2D | null;
-  pelletCacheDirty: boolean;
-  waveTimer: number;
-  waveMode: 'scatter' | 'chase';
-  globalDotCounter: number;
-  pelletsEaten: number;
-  ghostScoreMultiplier: number;
-  deathTimer: number;
-  levelCompleteTimer: number;
-  qualityLevel: 'high' | 'medium' | 'low';
-  showDPad: boolean;
-  fruit: {
-    type: string;
-    position: GridPosition | null;
-    points: number;
-    timer: number;
-  } | null;
-  fruitSpawnCount: number;
-}
-
-interface PacManGameProps {
-  settings: {
-    soundEnabled: boolean;
-    difficulty: 'easy' | 'normal' | 'hard';
-  };
-  updateHighScore: (gameId: string, score: number) => void;
-}
 
 // Maze constants
 const CELL_SIZE = 20;

--- a/src/components/games/pacman/types.ts
+++ b/src/components/games/pacman/types.ts
@@ -1,0 +1,97 @@
+import { Particle } from '../../../core/ParticleSystem';
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface GridPosition {
+  row: number;
+  col: number;
+}
+
+export type Direction = 'up' | 'down' | 'left' | 'right' | 'none';
+
+export interface Ghost {
+  id: string;
+  position: Position;
+  gridPos: GridPosition;
+  targetGridPos: GridPosition;
+  color: string;
+  mode: 'chase' | 'scatter' | 'frightened' | 'eaten' | 'in_house' | 'exiting';
+  speed: number;
+  aiType: 'blinky' | 'pinky' | 'inky' | 'clyde';
+  direction: Direction;
+  scatterTarget: GridPosition;
+  exitTimer: number;
+}
+
+export interface PowerUp {
+  type: 'speed' | 'freeze' | 'magnet' | 'shield';
+  gridPos: GridPosition;
+  duration: number;
+  icon: string;
+}
+
+export interface GameState {
+  pacman: {
+    position: Position;
+    gridPos: GridPosition;
+    targetGridPos: GridPosition;
+    previousGridPos: GridPosition;
+    direction: Direction;
+    nextDirection: Direction;
+    speed: number;
+    mouthOpen: boolean;
+    mouthTimer: number;
+    powerUpActive: string | null;
+    powerUpTimer: number;
+    invincibleTimer: number;
+    shieldHits: number;
+  };
+  ghosts: Ghost[];
+  maze: number[][];
+  pellets: Set<string>;
+  powerPellets: Set<string>;
+  powerUps: Map<string, PowerUp>;
+  score: number;
+  lives: number;
+  level: number;
+  combo: number;
+  comboTimer: number;
+  particles: Particle[];
+  gamePhase: 'ready' | 'playing' | 'levelComplete' | 'gameOver' | 'dying';
+  frightenedTimer: number;
+  freezeTimer: number;
+  lastUpdate: number;
+  mazeCacheCanvas: HTMLCanvasElement | null;
+  mazeCacheCtx: CanvasRenderingContext2D | null;
+  mazeCacheDirty: boolean;
+  pelletCacheCanvas: HTMLCanvasElement | null;
+  pelletCacheCtx: CanvasRenderingContext2D | null;
+  pelletCacheDirty: boolean;
+  waveTimer: number;
+  waveMode: 'scatter' | 'chase';
+  globalDotCounter: number;
+  pelletsEaten: number;
+  ghostScoreMultiplier: number;
+  deathTimer: number;
+  levelCompleteTimer: number;
+  qualityLevel: 'high' | 'medium' | 'low';
+  showDPad: boolean;
+  fruit: {
+    type: string;
+    position: GridPosition | null;
+    points: number;
+    timer: number;
+  } | null;
+  fruitSpawnCount: number;
+}
+
+export interface PacManGameProps {
+  settings: {
+    soundEnabled: boolean;
+    difficulty: 'easy' | 'normal' | 'hard';
+  };
+  updateHighScore: (gameId: string, score: number) => void;
+}


### PR DESCRIPTION
## Summary
- centralize Pac‑Man interfaces in `src/components/games/pacman/types.ts`
- import the new shared types in `PacManGame.tsx`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683b8d453310832eab70df029c73d1a1