### PR TITLE
Add power-up timer UI

### DIFF
--- a/src/core/SoundManager.ts
+++ b/src/core/SoundManager.ts
@@ -60,6 +60,11 @@ export class SoundManager {
     this.playTone(1320, 200);
   }
 
+  // Play a warning beep used for expiring timers
+  playWarning(): void {
+    this.playTone(1000, 150);
+  }
+
   // Play a short "waka waka" sound for eating pellets
   playEatPellet(): void {
     if (!this.enabled) return;


### PR DESCRIPTION
## Summary
- show active power-up icons next to snake
- animate arc countdown around each icon
- warn with a beep when a timer is almost over

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683b8d409150832eb80184ddb87fa67d