### PR TITLE
Add pacman level progression tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,9 +131,10 @@ function App() {
           </div>
           <div className="flex-1 overflow-hidden">
             {GameComponent && (
-              <GameComponent 
-                settings={settings} 
+              <GameComponent
+                settings={settings}
                 updateHighScore={updateHighScore}
+                {...(selectedGame === 'pacman' ? { pacmanProgress: stats.pacmanProgress } : {})}
               />
             )}
           </div>


### PR DESCRIPTION
## Summary
- extend `GameStats` with `pacmanProgress`
- persist stats immediately when calling `updateHighScore` or `incrementGamesPlayed`
- allow Pac-Man to read progression and choose unlocked levels
- save unlocked levels after completing a level
- pass progress from `App` to `PacManGame`

## Testing
- `npm run build`
- `npm run typecheck` *(fails: numerous existing TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_683b8d33c698832e9cd5666b9f13f8ef