### PR TITLE
Add Pac-Man maze editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { TetrisGame } from './components/games/TetrisGame';
 import { SpaceInvadersGame } from './components/games/SpaceInvadersGame';
 import { PacManGame } from './components/games/PacManGame';
 import { NeonJumpGame } from './components/games/NeonJumpGame';
+import { LevelEditor } from './components/games/pacman/LevelEditor';
 import { useSettings } from './hooks/useSettings';
 import { useStats } from './hooks/useStats';
 import { cleanupInputManager } from './core/InputManager';
@@ -36,6 +37,7 @@ const games = [
 function App() {
   const [selectedGame, setSelectedGame] = useState(null);
   const [showSettings, setShowSettings] = useState(false);
+  const [editingMaze, setEditingMaze] = useState(false);
   const [settings, setSettings] = useSettings();
   const { stats, updateHighScore, incrementGamesPlayed } = useStats();
 
@@ -108,7 +110,9 @@ function App() {
         />
       )}
       
-      {selectedGame ? (
+      {editingMaze ? (
+        <LevelEditor onBack={() => setEditingMaze(false)} />
+      ) : selectedGame ? (
         <div className="h-screen flex flex-col">
           <div className="bg-gradient-to-r from-gray-800 to-gray-900 p-4 flex items-center justify-between flex-shrink-0">
             <button
@@ -139,11 +143,12 @@ function App() {
           </div>
         </div>
       ) : (
-        <GameMenu 
+        <GameMenu
           games={games}
           stats={stats}
           onGameSelect={handleGameSelect}
           onShowSettings={() => setShowSettings(true)}
+          onEditMaze={() => setEditingMaze(true)}
         />
       )}
     </div>

--- a/src/components/games/PacManGame.tsx
+++ b/src/components/games/PacManGame.tsx
@@ -192,6 +192,26 @@ const MAZE_TEMPLATE: number[][] = [
   [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 ];
 
+const LAYOUTS_KEY = 'pacmanLayouts';
+const SELECTED_LAYOUT_KEY = 'pacmanSelectedLayout';
+
+const getStoredMaze = (): number[][] => {
+  try {
+    const selected = localStorage.getItem(SELECTED_LAYOUT_KEY);
+    if (!selected) return MAZE_TEMPLATE;
+    const layoutsStr = localStorage.getItem(LAYOUTS_KEY);
+    if (!layoutsStr) return MAZE_TEMPLATE;
+    const layouts = JSON.parse(layoutsStr);
+    const layout = layouts[selected];
+    if (Array.isArray(layout) && layout.length === MAZE_HEIGHT) {
+      return layout as number[][];
+    }
+  } catch (err) {
+    console.warn('Failed to load custom maze', err);
+  }
+  return MAZE_TEMPLATE;
+};
+
 // Create numeric key for grid position (more efficient than string concatenation)
 const getGridKey = (row: number, col: number): string => `${row * 1000 + col}`;
 const parseGridKey = (key: string): [number, number] => {
@@ -265,8 +285,8 @@ export const PacManGame: React.FC<PacManGameProps> = ({ settings, updateHighScor
   const initializeGame = useCallback((reset: boolean = false) => {
     const game = gameRef.current;
     
-    // Deep copy maze template
-    game.maze = MAZE_TEMPLATE.map(row => [...row]);
+    // Deep copy maze template (load custom layout if available)
+    game.maze = getStoredMaze().map(row => [...row]);
     
     // Initialize pellets with numeric keys
     game.pellets.clear();

--- a/src/components/games/pacman/LevelEditor.tsx
+++ b/src/components/games/pacman/LevelEditor.tsx
@@ -1,0 +1,139 @@
+import React, { useState, useEffect } from 'react';
+
+const MAZE_WIDTH = 28;
+const MAZE_HEIGHT = 31;
+
+// 0 = wall, 1 = pellet, 2 = power pellet, 3 = empty
+const DEFAULT_LAYOUT: number[][] = [
+  [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+  [0,1,1,1,1,1,1,1,1,1,1,1,1,0,0,1,1,1,1,1,1,1,1,1,1,1,1,0],
+  [0,1,0,0,0,0,1,0,0,0,0,0,1,0,0,1,0,0,0,0,0,1,0,0,0,0,1,0],
+  [0,2,0,0,0,0,1,0,0,0,0,0,1,0,0,1,0,0,0,0,0,1,0,0,0,0,2,0],
+  [0,1,0,0,0,0,1,0,0,0,0,0,1,0,0,1,0,0,0,0,0,1,0,0,0,0,1,0],
+  [0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0],
+  [0,1,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,1,0],
+  [0,1,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,1,0],
+  [0,1,1,1,1,1,1,0,0,1,1,1,1,0,0,1,1,1,1,0,0,1,1,1,1,1,1,0],
+  [0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0],
+  [0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0],
+  [0,0,0,0,0,0,1,0,0,1,1,1,1,1,1,1,1,1,1,0,0,1,0,0,0,0,0,0],
+  [0,0,0,0,0,0,1,0,0,1,0,0,0,3,3,0,0,0,1,0,0,1,0,0,0,0,0,0],
+  [0,0,0,0,0,0,1,0,0,1,0,3,3,3,3,3,3,0,1,0,0,1,0,0,0,0,0,0],
+  [1,1,1,1,1,1,1,1,1,1,0,3,3,3,3,3,3,0,1,1,1,1,1,1,1,1,1,1],
+  [0,0,0,0,0,0,1,0,0,1,0,3,3,3,3,3,3,0,1,0,0,1,0,0,0,0,0,0],
+  [0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0],
+  [0,0,0,0,0,0,1,0,0,1,1,1,1,1,1,1,1,1,1,0,0,1,0,0,0,0,0,0],
+  [0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0],
+  [0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0],
+  [0,1,1,1,1,1,1,1,1,1,1,1,1,0,0,1,1,1,1,1,1,1,1,1,1,1,1,0],
+  [0,1,0,0,0,0,1,0,0,0,0,0,1,0,0,1,0,0,0,0,0,1,0,0,0,0,1,0],
+  [0,1,0,0,0,0,1,0,0,0,0,0,1,0,0,1,0,0,0,0,0,1,0,0,0,0,1,0],
+  [0,2,1,1,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,1,1,2,0],
+  [0,0,0,1,0,0,1,0,0,1,0,0,0,0,0,0,0,0,1,0,0,1,0,0,1,0,0,0],
+  [0,0,0,1,0,0,1,0,0,1,0,0,0,0,0,0,0,0,1,0,0,1,0,0,1,0,0,0],
+  [0,1,1,1,1,1,1,0,0,1,1,1,1,0,0,1,1,1,1,0,0,1,1,1,1,1,1,0],
+  [0,1,0,0,0,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,0,0,1,0],
+  [0,1,0,0,0,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,0,0,1,0],
+  [0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0],
+  [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+];
+
+const STORAGE_KEY = 'pacmanLayouts';
+const SELECTED_KEY = 'pacmanSelectedLayout';
+
+interface LevelEditorProps {
+  onBack: () => void;
+}
+
+const loadLayouts = (): Record<string, number[][]> => {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      return JSON.parse(saved);
+    }
+  } catch (err) {
+    console.warn('Failed to load layouts', err);
+  }
+  return {};
+};
+
+const saveLayouts = (layouts: Record<string, number[][]>): void => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(layouts));
+  } catch (err) {
+    console.error('Failed to save layouts', err);
+  }
+};
+
+export const LevelEditor: React.FC<LevelEditorProps> = ({ onBack }) => {
+  const [layouts, setLayouts] = useState<Record<string, number[][]>>(loadLayouts);
+  const initialName = localStorage.getItem(SELECTED_KEY) || Object.keys(layouts)[0] || 'default';
+  const [name, setName] = useState(initialName);
+  const [grid, setGrid] = useState<number[][]>(() => {
+    const layout = layouts[initialName];
+    return layout ? layout.map(row => [...row]) : DEFAULT_LAYOUT.map(row => [...row]);
+  });
+
+  useEffect(() => {
+    saveLayouts(layouts);
+  }, [layouts]);
+
+  const toggleCell = (r: number, c: number) => {
+    setGrid(prev => {
+      const copy = prev.map(row => [...row]);
+      copy[r][c] = (copy[r][c] + 1) % 4;
+      return copy;
+    });
+  };
+
+  const handleSave = () => {
+    const layoutName = prompt('Layout name', name) || name;
+    setName(layoutName);
+    const updated = { ...layouts, [layoutName]: grid };
+    setLayouts(updated);
+    localStorage.setItem(SELECTED_KEY, layoutName);
+  };
+
+  const handleLoad = (layoutName: string) => {
+    const layout = layouts[layoutName];
+    if (layout) {
+      setName(layoutName);
+      setGrid(layout.map(row => [...row]));
+      localStorage.setItem(SELECTED_KEY, layoutName);
+    }
+  };
+
+  const colors = ['#1e3a8a', '#facc15', '#f472b6', '#111827'];
+
+  return (
+    <div className="p-4 text-white flex flex-col items-center">
+      <div className="mb-4 w-full flex justify-between items-center">
+        <button onClick={onBack} className="bg-gray-700 px-4 py-2 rounded">Back</button>
+        <div className="flex items-center gap-2">
+          <select value={name} onChange={e => handleLoad(e.target.value)} className="bg-gray-800 p-1 rounded">
+            {[name, ...Object.keys(layouts)].filter((v, i, a) => a.indexOf(v) === i).map(n => (
+              <option key={n} value={n}>{n}</option>
+            ))}
+          </select>
+          <button onClick={handleSave} className="bg-green-600 px-3 py-1 rounded">Save</button>
+        </div>
+      </div>
+      <div
+        className="grid"
+        style={{ gridTemplateColumns: `repeat(${MAZE_WIDTH}, 16px)` }}
+      >
+        {grid.map((row, r) =>
+          row.map((cell, c) => (
+            <div
+              key={`${r}-${c}`}
+              onClick={() => toggleCell(r, c)}
+              style={{ width: 16, height: 16, backgroundColor: colors[cell], border: '1px solid #111' }}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+LevelEditor.displayName = 'LevelEditor';

--- a/src/components/ui/GameMenu.tsx
+++ b/src/components/ui/GameMenu.tsx
@@ -17,6 +17,7 @@ interface GameMenuProps {
   stats: Stats;
   onGameSelect: (gameId: string) => void;
   onShowSettings: () => void;
+  onEditMaze: () => void;
 }
 
 interface GameDetails {
@@ -34,7 +35,7 @@ const gameDetails: Record<string, GameDetails> = {
   pacman: { color: 'from-yellow-400 to-orange-600', description: 'Neon maze adventure!' }
 };
 
-export const GameMenu: React.FC<GameMenuProps> = ({ games, stats, onGameSelect, onShowSettings }) => (
+export const GameMenu: React.FC<GameMenuProps> = ({ games, stats, onGameSelect, onShowSettings, onEditMaze }) => (
   <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 p-4 flex flex-col items-center justify-center">
     <div className="absolute inset-0 overflow-hidden">
       <div className="absolute -top-40 -right-40 w-80 h-80 bg-purple-500 rounded-full mix-blend-multiply filter blur-xl opacity-20 animate-blob"></div>
@@ -79,6 +80,12 @@ export const GameMenu: React.FC<GameMenuProps> = ({ games, stats, onGameSelect, 
       >
         <Settings size={20} />
         Settings
+      </button>
+      <button
+        onClick={onEditMaze}
+        className="px-6 py-3 bg-gray-800 text-white rounded-lg hover:bg-gray-700 transition-colors"
+      >
+        Edit Maze
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add Pac-Man maze level editor component with save/load to localStorage
- allow Pac-Man game to load selected custom layout
- update game menu with Edit Maze button
- integrate editor into app flow

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683b8d3190d0832ebee6937b1d717122