### PR TITLE
Fix pacman initialization bug

### DIFF
--- a/src/components/games/PacManGame.tsx
+++ b/src/components/games/PacManGame.tsx
@@ -134,7 +134,8 @@ export const PacManGame: React.FC<PacManGameProps> = ({ settings, updateHighScor
       previousGridPos: { row: 23, col: 14 },
       direction: 'none',
       nextDirection: 'none',
-      speed: 0.15 + (game.level - 1) * 0.01,
+      // Initial speed based on starting level
+      speed: 0.15 + (level - 1) * 0.01,
       mouthOpen: true,
       mouthTimer: 0,
       powerUpActive: null,


### PR DESCRIPTION
## Summary
- fix variable reference in PacManGame initial state

## Testing
- `npm run build`
- `npm run lint` *(fails: 7 errors, 211 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_683b999c4c50832e8cb1057ce69e3b73