### PR TITLE
Fix NeonJump overlay and stats

### DIFF
--- a/src/components/games/NeonJumpGame.tsx
+++ b/src/components/games/NeonJumpGame.tsx
@@ -7760,7 +7760,8 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
     }
 
     // Check "too high" death condition to prevent player getting lost off-screen
-    const MAX_HEIGHT_ABOVE_CAMERA_TOP = 1200; // Approximately 2 screen heights
+    // Allow greater vertical exploration before triggering fail-safe
+    const MAX_HEIGHT_ABOVE_CAMERA_TOP = 5000; // Prevent premature game over
     // player.position.y is top of player, game.camera.y is top of camera
     // If player.position.y is much more negative, they are higher up
     if ((game.camera.y - player.position.y) > MAX_HEIGHT_ABOVE_CAMERA_TOP) {
@@ -7866,7 +7867,8 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
           const perfectPoints = scoreManagerRef.current.recordPerfectLanding(fallVelocity);
           if (perfectPoints > 0 && gameFeelManagerRef.current) {
             gameFeelManagerRef.current.cameraShake(0.5, 100);
-            gameFeelManagerRef.current.colorFlash('#00ff00', 0.1, 80); // Much shorter duration
+            // Softer flash to reduce visual clutter when bonuses stack
+            gameFeelManagerRef.current.colorFlash('#00ff00', 0.05, 60);
           }
           
           // CHECKPOINT 5: Landing particle effects
@@ -9471,7 +9473,8 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
     
     // Update atmospheric effects based on height
     const heightFactor = Math.max(0, -game.camera.y / 1000);
-    game.atmosphericColorShift = heightFactor;
+    // Limit intensity to avoid excessive brightness at extreme heights
+    game.atmosphericColorShift = Math.min(heightFactor, 0.5);
     
     // Generate enhanced particle effects
     if (player.state === 'jumping' && Math.random() < 0.3) {
@@ -9580,7 +9583,7 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
     if (game.atmosphericColorShift > 0) {
       ctx.save();
       ctx.globalCompositeOperation = 'overlay';
-      ctx.fillStyle = `rgba(0, 255, 255, ${game.atmosphericColorShift * 0.2})`;
+      ctx.fillStyle = `rgba(0, 255, 255, ${game.atmosphericColorShift * 0.15})`;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
       ctx.restore();
     }
@@ -9595,7 +9598,7 @@ export const NeonJumpGame: React.FC<NeonJumpGameProps> = ({ settings, updateHigh
         
         ctx.save();
         ctx.globalCompositeOperation = 'screen';
-        ctx.globalAlpha = light.intensity * 0.3;
+        ctx.globalAlpha = light.intensity * 0.2;
         
         const gradient = ctx.createRadialGradient(
           screenX, screenY, 0,

--- a/src/core/GameTypes.ts
+++ b/src/core/GameTypes.ts
@@ -12,6 +12,8 @@ export interface GameStats {
     breakout: number;
     tetris: number;
     spaceInvaders: number;
+    pacman: number;
+    neonJump: number;
   };
   gamesPlayed: number;
   totalScore: number;

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -1,6 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
 
-export type GameType = 'snake' | 'pong' | 'breakout' | 'tetris' | 'spaceInvaders' | 'pacman';
+export type GameType =
+  | 'snake'
+  | 'pong'
+  | 'breakout'
+  | 'tetris'
+  | 'spaceInvaders'
+  | 'pacman'
+  | 'neonJump';
 
 export interface HighScores {
   snake: number;
@@ -9,6 +16,7 @@ export interface HighScores {
   tetris: number;
   spaceInvaders: number;
   pacman?: number; // Optional for backward compatibility
+  neonJump?: number;
 }
 
 export interface Achievement {
@@ -39,7 +47,8 @@ const DEFAULT_STATS: GameStats = {
     breakout: 0,
     tetris: 0,
     spaceInvaders: 0,
-    pacman: 0
+    pacman: 0,
+    neonJump: 0
   },
   gamesPlayed: 0,
   totalScore: 0,
@@ -50,7 +59,15 @@ const STORAGE_KEY = 'retroGameStats';
 const MAX_STORAGE_SIZE = 2 * 1024 * 1024; // 2MB limit for stats
 const MAX_ACHIEVEMENTS = 1000; // Prevent unlimited growth
 
-const VALID_GAME_TYPES: GameType[] = ['snake', 'pong', 'breakout', 'tetris', 'spaceInvaders', 'pacman'];
+const VALID_GAME_TYPES: GameType[] = [
+  'snake',
+  'pong',
+  'breakout',
+  'tetris',
+  'spaceInvaders',
+  'pacman',
+  'neonJump'
+];
 
 // Validation function to ensure stats object has correct shape and types
 const validateStats = (data: unknown): GameStats | null => {
@@ -73,7 +90,8 @@ const validateStats = (data: unknown): GameStats | null => {
       breakout: 0,
       tetris: 0,
       spaceInvaders: 0,
-      pacman: 0
+      pacman: 0,
+      neonJump: 0
     };
 
     // Validate each game score


### PR DESCRIPTION
## Summary
- recognize neonJump in stats tracking
- prevent blinding overlays and early game over in NeonJump
- cap lighting intensity and height atmospheric effect

## Testing
- `npm run build`
- `npm run lint` *(fails: many warnings and errors)*


------
https://chatgpt.com/codex/tasks/task_e_683b99717c28832ea823fa6408ec30bd